### PR TITLE
[17277] Add install dependencies actions

### DIFF
--- a/.github/actions/install-apt-packages/action.yml
+++ b/.github/actions/install-apt-packages/action.yml
@@ -1,0 +1,25 @@
+name: 'install-apt-packages'
+description: 'Install necessary apt packages'
+runs:
+  using: "composite"
+  steps:
+    - id: install-apt-packages
+      run: |
+        sudo apt update && sudo apt -y install \
+          clang-tidy \
+          curl \
+          doxygen \
+          graphviz \
+          grep \
+          imagemagick \
+          libasio-dev \
+          libtinyxml2-dev \
+          libyaml-cpp-dev \
+          lcov \
+          python3 \
+          python3-pip \
+          python3-sphinxcontrib.spelling \
+          python3-venv \
+          software-properties-common \
+          wget
+      shell: bash

--- a/.github/actions/install-python-packages/action.yml
+++ b/.github/actions/install-python-packages/action.yml
@@ -1,0 +1,24 @@
+name: 'install-python-packages'
+description: 'Install necessary python packages'
+runs:
+  using: "composite"
+  steps:
+    - id: install-python-packages
+      run: |
+        sudo pip3 install -U \
+          colcon-common-extensions \
+          colcon-mixin \
+          doc8==0.10.1 \
+          gcovr==5.0 \
+          GitPython==3.1.24 \
+          jsonschema \
+          pyyaml \
+          setuptools==58.2.0 \
+          sphinx==4.3.1 \
+          sphinx_rtd_theme==0.5.2 \
+          sphinxcontrib.spelling==7.2.1 \
+          sphinxcontrib-imagehelper==1.1.1 \
+          sphinx-tabs==3.2.0 \
+          tomark \
+          vcstool
+      shell: bash


### PR DESCRIPTION
This PR includes 2 generic actions to install apt and python dependencies. This actions are based on those found in [Fast-DDS-statistics-backend](https://github.com/eProsima/Fast-DDS-statistics-backend) and [DDS Router](https://github.com/eProsima/DDS-Router)