### PR TITLE
[18503] Add mirror and create PR external actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ The main idea is to collect every repeated or generic step of any CI to have a s
 - [Dependencies built](#dependencies-built)
   - [Artifacts uploaded](#artifacts-uploaded)
   - [Generate artifacts manually](#generate-artifacts-manually)
+- [External Actions](#external-actions)
 
 ---
 
@@ -221,3 +222,19 @@ Then, run the `manual_build` workflow with these arguments:
 - `artifacts_name_postfix`: Postfix of the name of the artifact to generate.
 
 The result artifacts will be called `<artifacts_name_prefix>_<os>_<cmake_build_type><artifacts_name_postfix>`.
+
+## External Actions
+
+This repository also includes a wrapper around the external actions being used by eProsima CI workflows.
+Thus, the maintainability and upgrading of these actions is performed in a single step.
+Find below the external actions listed:
+
+| External Action | Description | LICENSE |
+|---|---|---|
+| [action-download-artifact](external/action-download-artifact/action.yml) | Download and extract an artifact | MIT license |
+| [checkout](external/checkout/action.yml) | Checkout repository | MIT license |
+| [codecov-action](external/codecov-action/action.yml) | Upload coverage report to codecov.io | MIT license |
+| [create-pull-request](external/create-pull-request/action.yml) | Create PR | MIT license |
+| [mirror-branch-action](external/mirror-branch-action/action.yml) | Mirror branch within the same repository | Apache-2.0 license |
+| [upload-artifact](external/upload-artifact/action.yml) | Upload build artifact | MIT license |
+| [wait-on-check-action](external/wait-on-check-action/action.yml) | Wait on certain check | MIT license |

--- a/external/checkout/action.yml
+++ b/external/checkout/action.yml
@@ -71,7 +71,7 @@ runs:
   using: composite
   steps:
 
-    - name: Download dependency
+    - name: Checkout repository
       uses: actions/checkout@v3
       with:
         repository: ${{ inputs.repository }}

--- a/external/create-pull-request/action.yml
+++ b/external/create-pull-request/action.yml
@@ -1,0 +1,115 @@
+name: 'Create Pull Request'
+description: 'https://github.com/peter-evans/create-pull-request'
+
+inputs:
+
+  token:
+    description: 'GITHUB_TOKEN or a `repo` scoped Personal Access Token (PAT)'
+    default: ${{ github.token }}
+  path:
+    description: >
+      Relative path under $GITHUB_WORKSPACE to the repository.
+      Defaults to $GITHUB_WORKSPACE.
+  add-paths:
+    description: >
+      A comma or newline-separated list of file paths to commit.
+      Paths should follow git's pathspec syntax.
+      Defaults to adding all new and modified files.
+  commit-message:
+    description: 'The message to use when committing changes.'
+    default: '[create-pull-request] automated change'
+  committer:
+    description: >
+      The committer name and email address in the format `Display Name <email@address.com>`.
+      Defaults to the GitHub Actions bot user.
+    default: 'GitHub <noreply@github.com>'
+  author:
+    description: >
+      The author name and email address in the format `Display Name <email@address.com>`.
+      Defaults to the user who triggered the workflow run.
+    default: '${{ github.actor }} <${{ github.actor }}@users.noreply.github.com>'
+  signoff:
+    description: 'Add `Signed-off-by` line by the committer at the end of the commit log message.'
+    default: false
+  branch:
+    description: 'The pull request branch name.'
+    default: 'create-pull-request/patch'
+  delete-branch:
+    description: >
+      Delete the `branch` when closing pull requests, and when undeleted after merging.
+      Recommend `true`.
+    default: false
+  branch-suffix:
+    description: 'The branch suffix type when using the alternative branching strategy.'
+  base:
+    description: >
+      The pull request base branch.
+      Defaults to the branch checked out in the workflow.
+  push-to-fork:
+    description: >
+      A fork of the checked out parent repository to which the pull request branch will be pushed.
+      e.g. `owner/repo-fork`.
+      The pull request will be created to merge the fork's branch into the parent's base.
+  title:
+    description: 'The title of the pull request.'
+    default: 'Changes by create-pull-request action'
+  body:
+    description: 'The body of the pull request.'
+    default: 'Automated changes by [create-pull-request](https://github.com/peter-evans/create-pull-request) GitHub action'
+  body-path:
+    description: 'The path to a file containing the pull request body. Takes precedence over `body`.'
+  labels:
+    description: 'A comma or newline separated list of labels.'
+  assignees:
+    description: 'A comma or newline separated list of assignees (GitHub usernames).'
+  reviewers:
+    description: 'A comma or newline separated list of reviewers (GitHub usernames) to request a review from.'
+  team-reviewers:
+    description: >
+      A comma or newline separated list of GitHub teams to request a review from.
+      Note that a `repo` scoped Personal Access Token (PAT) may be required.
+  milestone:
+    description: 'The number of the milestone to associate the pull request with.'
+  draft:
+    description: 'Create a draft pull request. It is not possible to change draft status after creation except through the web interface'
+    default: false
+
+outputs:
+
+  pull-request-number:
+    description: 'The pull request number'
+  pull-request-url:
+    description: 'The URL of the pull request.'
+  pull-request-operation:
+    description: 'The pull request operation performed by the action, `created`, `updated` or `closed`.'
+  pull-request-head-sha:
+    description: 'The commit SHA of the pull request branch.'
+
+runs:
+  using: composite
+  steps:
+
+    - name: Create PR
+      uses: peter-evans/create-pull-request@v5
+      with:
+        token: ${{ inputs.token }}
+        path: ${{ inputs.path }}
+        add-paths: ${{ inputs.add-paths }}
+        commit-message: ${{ inputs.commit-message }}
+        committer: ${{ inputs.committer }}
+        author: ${{ inputs.author }}
+        signoff: ${{ inputs.signoff }}
+        branch: ${{ inputs.branch }}
+        delete-branch: ${{ inputs.delete-branch }}
+        branch-suffix: ${{ inputs.branch-suffix }}
+        base: ${{ inputs.base }}
+        push-to-fork: ${{ inputs.push-to-fork }}
+        title: ${{ inputs.title }}
+        body: ${{ inputs.body }}
+        body-path: ${{ inputs.body-path }}
+        labels: ${{ inputs.labels }}
+        assignees: ${{ inputs.assignees }}
+        reviewers: ${{ inputs.reviewers }}
+        team-reviewers: ${{ inputs.team-reviewers }}
+        milestone: ${{ inputs.milestone }}
+        draft: ${{ inputs.draft }}

--- a/external/mirror-branch-action/action.yml
+++ b/external/mirror-branch-action/action.yml
@@ -1,0 +1,25 @@
+name: 'Mirror Branch'
+description: 'https://github.com/google/mirror-branch-action'
+
+inputs:
+
+  github-token:
+    description: 'This should be `secrets.GITHUB_TOKEN`.'
+    required: true
+  source:
+    description: 'Name of the source branch'
+    required: true
+  dest:
+    description: 'Name of the destination branch'
+    required: true
+
+runs:
+  using: composite
+  steps:
+
+    - name: Mirror branch
+      uses: google/mirror-branch-action@v1.0
+      with:
+        github-token: ${{ inputs.github-token }}
+        source: ${{ inputs.source }}
+        dest: ${{ inputs.dest }}


### PR DESCRIPTION
Create PR action is tested in eProsima/DDS-Suite#77. Successful workflow can be seen [here](https://github.com/eProsima/DDS-Suite/actions/runs/4924174924), though as no change is detected, no new PR has been opened.

Mirror action is updated in eProsima/Fast-DDS#3503. This workflow only runs on pushes to master branch. Consequently, it will be tested once it is merged.