### PR TITLE
[18503] Upgrade external action mirror branch

### DIFF
--- a/external/mirror-branch-action/action.yml
+++ b/external/mirror-branch-action/action.yml
@@ -18,7 +18,7 @@ runs:
   steps:
 
     - name: Mirror branch
-      uses: google/mirror-branch-action@v1.0
+      uses: google/mirror-branch-action@v2.0
       with:
         github-token: ${{ inputs.github-token }}
         source: ${{ inputs.source }}


### PR DESCRIPTION
Recently the [mirror branch external action has a new release](https://github.com/google/mirror-branch-action/releases) to fix the Node JS 12 deprecation warnings and upgrade dependencies. This PR upgrades to the latest release.