### PR TITLE
[20023] Remove empy fixed version for colcon install

### DIFF
--- a/ubuntu/install_colcon/action.yml
+++ b/ubuntu/install_colcon/action.yml
@@ -8,7 +8,7 @@ runs:
     - name: Install colcon
       uses: eProsima/eProsima-CI/ubuntu/install_python_packages@main
       with:
-        packages: 'empy==3.3.4 setuptools==58.3.0 colcon-common-extensions colcon-mixin'
+        packages: 'setuptools==58.3.0 colcon-common-extensions colcon-mixin'
         upgrade: true
 
     - name: Download default colcon mixin

--- a/windows/install_colcon/action.yml
+++ b/windows/install_colcon/action.yml
@@ -7,7 +7,7 @@ runs:
     - name: Install colcon
       uses: eProsima/eProsima-CI/windows/install_python_packages@main
       with:
-        packages: 'empy==3.3.4 vcstool setuptools==58.3.0 colcon-common-extensions colcon-mixin'
+        packages: 'vcstool setuptools==58.3.0 colcon-common-extensions colcon-mixin'
         upgrade: true
 
     - name: Download default colcon mixin


### PR DESCRIPTION
colcon-core v0.15.1 solved the empy dependency problem, so we can remove the fixed empy here and defer to colcon's