### PR TITLE
[20255] Add version option to OpenSSL Windows install action

### DIFF
--- a/windows/install_fastdds_dependencies/action.yml
+++ b/windows/install_fastdds_dependencies/action.yml
@@ -20,4 +20,6 @@ runs:
         cmake_build_type: ${{ inputs.cmake_build_type }}
 
     - name: Install Open SSL
-      uses: eProsima/eProsima-CI/windows/install_openssl@main
+      uses: eProsima/eprosima-CI/windows/install_openssl@main
+      with:
+        version: '3.1.1'

--- a/windows/install_openssl/action.yml
+++ b/windows/install_openssl/action.yml
@@ -1,5 +1,12 @@
 name: install_openssl
-description: Install and setup Open SSL for linking and building in Windows
+description: Install and setup OpenSSL for linking and building in Windows
+
+inputs:
+
+  version:
+    description: 'OpenSSL version (default: latests)'
+    required: false
+    default: ''
 
 runs:
   using: composite
@@ -9,9 +16,15 @@ runs:
       shell: pwsh
       run: |
 
-        "::group::Install Open SSL"
+        "::group::Install OpenSSL"
 
-        choco install openssl -yr --no-progress;
+        if (${{ inputs.version }} -eq "true") {
+          $VERSION = "--version ${{ inputs.version }}"
+        } else {
+          $VERSION = ""
+        }
+
+        choco install openssl $VERSION -yr --no-progress;
         @(ls -Path C:\Windows\System32\* -Include libssl-*.dll; ls -Path C:\Windows\SysWOW64\* -Include libssl-*.dll) | rm -ErrorAction SilentlyContinue
 
         "::endgroup::"

--- a/windows/install_openssl/action.yml
+++ b/windows/install_openssl/action.yml
@@ -19,7 +19,7 @@ runs:
         "::group::Install OpenSSL"
 
         if (-not [string]::IsNullOrWhiteSpace( "${{ inputs.version }}" )) {
-          $VERSION = "--version ${{ inputs.version }}"
+          $VERSION = "--version=${{ inputs.version }}"
         } else {
           $VERSION = ""
         }

--- a/windows/install_openssl/action.yml
+++ b/windows/install_openssl/action.yml
@@ -18,7 +18,7 @@ runs:
 
         "::group::Install OpenSSL"
 
-        if (${{ inputs.version }} -eq "true") {
+        if (-not [string]::IsNullOrWhiteSpace( "${{ inputs.version }}" )) {
           $VERSION = "--version ${{ inputs.version }}"
         } else {
           $VERSION = ""


### PR DESCRIPTION
This PR adds an optional `version` argument to OpenSSL installation in Windows. If not specified, the latest version is installed. Tested in:
*  eProsima/Fast-DDS#4248