### PR TITLE
Set the number of random bits for mmap to 28

### DIFF
--- a/ubuntu/colcon_build/action.yml
+++ b/ubuntu/colcon_build/action.yml
@@ -50,6 +50,9 @@ runs:
     - name: Build workspace with colcon
       run: |
 
+        # https://github.com/actions/runner-images/issues/9491
+        sudo sysctl vm.mmap_rnd_bits=28
+
         echo "::group::Compile using colcon ${{ inputs.workspace }}"
 
         if [[ ! -z "${{ inputs.workspace_dependencies }}" ]]; then


### PR DESCRIPTION
<!--
    Provide a general summary of your changes in the Title above
    It must be meaningful and coherent with the changes
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
-->

## Description

<!--
    Describe changes in detail.
    This includes depicting the context, use case or current behavior and describe the proposed changes.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->

Since the roll out of [Github Ubuntu 22.04 (20240310) Image](https://github.com/actions/runner-images/releases/tag/ubuntu22%2F20240310.1), ASan and TSan jobs have been failing. The issue was reported in actions/runner-images#9491 and fixed in actions/runner-images#9513. Until that fix is deployed, this PR:

1. Sets kernel param `vm.mmap_rnd_bits` to 28 as a workaround.

## Contributor Checklist
- [ ] Commit messages follow the company guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [ ] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- [ ] New features have been added to the `versions.md` and `README.md` files (if applicable).

## Reviewer Checklist
- [ ] The title and description correctly express the PR's purpose.
- [ ] The Contributor checklist is correctly filled.
