### PR TITLE
Only update mmap_rnd_bits in Linux runners

### DIFF
--- a/ubuntu/colcon_build/action.yml
+++ b/ubuntu/colcon_build/action.yml
@@ -51,7 +51,10 @@ runs:
       run: |
 
         # https://github.com/actions/runner-images/issues/9491
-        sudo sysctl vm.mmap_rnd_bits=28
+        if [[ ${RUNNER_OS} == "Linux" ]]
+        then
+          sudo sysctl vm.mmap_rnd_bits=28
+        fi
 
         echo "::group::Compile using colcon ${{ inputs.workspace }}"
 


### PR DESCRIPTION
<!--
    Provide a general summary of your changes in the Title above
    It must be meaningful and coherent with the changes
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
-->

## Description

<!--
    Describe changes in detail.
    This includes depicting the context, use case or current behavior and describe the proposed changes.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->

#72 fixed the `vm.mmap_rnd_bits` to 28 in the Ubuntu `colcon_build` action. This has broken Fast DDS macOS CIs, since the `colcon_build` used for macOS through the multiplatform is in fact the Ubuntu one. This PR fixes this issue by only setting `mmap_rnd_bits` on `Linux` runners. This is done using default env var `RUNNER_OS` (see [here](https://docs.github.com/en/actions/learn-github-actions/variables#detecting-the-operating-system)).

## Contributor Checklist

- [x] Commit messages follow the company guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [x] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- _N/A_: New features have been added to the `versions.md` and `README.md` files (if applicable).

## Reviewer Checklist

- [x] The title and description correctly express the PR's purpose.
- [x] The Contributor checklist is correctly filled.
