### PR TITLE
Use GCC 12 in TSAN action

### DIFF
--- a/multiplatform/tsan_build_test/action.yml
+++ b/multiplatform/tsan_build_test/action.yml
@@ -43,6 +43,11 @@ runs:
 
     - name: Build and test
       id: build_and_test
+      env:
+        # GCC 11.3 (Ubuntu Jammy default) produces several false positives regarding timed synchronization protocols
+        # These issues were fixed in GCC 12 so we upgrade to that version.
+        CC: gcc-12
+        CXX: g++-12
       uses: eProsima/eProsima-CI/multiplatform/colcon_build_test@main
       with:
         packages_names: ${{ inputs.packages_names }}


### PR DESCRIPTION
<!--
    Provide a general summary of your changes in the Title above
    It must be meaningful and coherent with the changes
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
-->

## Description
GCC 11.3 (Ubuntu Jammy default) produces several false positives regarding timed synchronization protocols. These issues were fixed in GCC 12 so we upgrade to that version.
<!--
    Describe changes in detail.
    This includes depicting the context, use case or current behavior and describe the proposed changes.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->

## Contributor Checklist
- [x] Commit messages follow the company guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [x] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- [x] New features have been added to the `versions.md` and `README.md` files (if applicable).

## Reviewer Checklist
- [ ] The title and description correctly express the PR's purpose.
- [ ] The Contributor checklist is correctly filled.
