### PR TITLE
[20965] Correct user path argument when installing python packages in ubuntu and macos

### DIFF
--- a/macos/install_python_packages/action.yml
+++ b/macos/install_python_packages/action.yml
@@ -38,14 +38,14 @@ runs:
         # Install python packages if any
         if [[ ! -z "${{ inputs.packages }}" ]]
         then
-          pip3 install ${UPGRADE_FLAG} -U \
+          pip3 install ${UPGRADE_FLAG} --user \
             ${{ inputs.packages }}
         fi
 
         # Install requirements file if any
         if [[ ! -z "${{ inputs.requirements_file_name }}" ]]
         then
-          pip3 install ${UPGRADE_FLAG} -U \
+          pip3 install ${UPGRADE_FLAG} --user \
             -r ${{ inputs.requirements_file_name }}
         fi
 

--- a/ubuntu/install_python_packages/action.yml
+++ b/ubuntu/install_python_packages/action.yml
@@ -36,13 +36,13 @@ runs:
 
         # Install python packages if any
         if [[ ! -z "${{ inputs.packages }}" ]] ; then
-          pip3 install ${UPGRADE_FLAG} -U \
+          pip3 install ${UPGRADE_FLAG} --user \
             ${{ inputs.packages }}
         fi
 
         # Install requirements file if any
         if [[ ! -z "${{ inputs.requirements_file_name }}" ]] ; then
-          pip3 install ${UPGRADE_FLAG} -U \
+          pip3 install ${UPGRADE_FLAG} --user \
             -r ${{ inputs.requirements_file_name }}
         fi
 


### PR DESCRIPTION

<!--
    Provide a general summary of your changes in the Title above
    It must be meaningful and coherent with the changes
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
-->

## Description

<!--
    Describe changes in detail.
    This includes depicting the context, use case or current behavior and describe the proposed changes.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->

This PR corrects the installation path argument when installing python packages in Ubuntu and Macos. `-U` flag is `upgrade` not a shortcut for `--user`. 

## Contributor Checklist
- [X] Commit messages follow the company guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [X] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- _N/A_ New features have been added to the `versions.md` and `README.md` files (if applicable).

## Reviewer Checklist
- [x] The title and description correctly express the PR's purpose.
- [x] The Contributor checklist is correctly filled.
