### PR TITLE
[20989] Fix macOS colcon installation

### DIFF
--- a/macos/install_colcon/action.yml
+++ b/macos/install_colcon/action.yml
@@ -9,7 +9,7 @@ runs:
       uses: eProsima/eProsima-CI/macos/install_python_packages@main
       with:
         packages: 'setuptools==58.3.0 colcon-common-extensions colcon-mixin'
-        upgrade: false
+        upgrade: true
 
     - name: Download default colcon mixin
       shell: bash

--- a/macos/install_python_packages/action.yml
+++ b/macos/install_python_packages/action.yml
@@ -38,14 +38,14 @@ runs:
         # Install python packages if any
         if [[ ! -z "${{ inputs.packages }}" ]]
         then
-          pip3 install ${UPGRADE_FLAG} --user \
+          pip3 install ${UPGRADE_FLAG} \
             ${{ inputs.packages }}
         fi
 
         # Install requirements file if any
         if [[ ! -z "${{ inputs.requirements_file_name }}" ]]
         then
-          pip3 install ${UPGRADE_FLAG} --user \
+          pip3 install ${UPGRADE_FLAG} \
             -r ${{ inputs.requirements_file_name }}
         fi
 


### PR DESCRIPTION
<!--
    Provide a general summary of your changes in the Title above
    It must be meaningful and coherent with the changes
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
-->

## Description

<!--
    Describe changes in detail.
    This includes depicting the context, use case or current behavior and describe the proposed changes.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->

After #90, if `install_colcon` is used within a macOS image in combination with `setup_python`, the installed binaries could not be directly run since the installation directory was not in the `PATH`. This PR fixes that by not passing the `--user` flag when installing python packages in macOS.
The PR also calls `install_python_packages` with the `upgrade` flag set to `true` to mirror the Ubuntu behaviour.

The correctness of the installation with these changes can be seen [here](https://github.com/eProsima/Fast-DDS/actions/runs/9157019274/job/25173710498).

## Contributor Checklist

- [x] Commit messages follow the company guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [x] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- _N/A_: New features have been added to the `versions.md` and `README.md` files (if applicable).

## Reviewer Checklist

- [ ] The title and description correctly express the PR's purpose.
- [ ] The Contributor checklist is correctly filled.
