### PR TITLE
[20822] Remove cat from windows colcon build action

### DIFF
--- a/versions.md
+++ b/versions.md
@@ -32,6 +32,8 @@ The [Forthcoming](#forthcoming) section includes those features added in `main` 
 
 The upcoming release will include the following **features**:
 
+- Remove `cat colcon.meta` command from windows colcon build action.
+
 ## v0.19.0
 
 - Fix upload artifact action to allow branch names in the name (by removing forbidden characters).

--- a/windows/colcon_build/action.yml
+++ b/windows/colcon_build/action.yml
@@ -65,7 +65,6 @@ runs:
         }
 
         echo "Using colcon.meta file <$env:COLCON_BUILD_META_>"
-        cat $env:COLCON_BUILD_META_
 
         cd ${{ inputs.workspace }}
 


### PR DESCRIPTION
<!--
    Provide a general summary of your changes in the Title above
    It must be meaningful and coherent with the changes
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
-->

## Description
The windows colcon build action has a `cat colcon.meta` command that prints in the terminal the given colcon meta (I assume that it was introduced for debugging purposes).
As long as some changes have been introduced in the Fast DDS CI to use different colcon.meta files at the same time (feature allowed by the `--metas` argument), this `cat` command does not recognize the meta file if more than one are provided.
This PR removes the `cat`.

Related PR:
- #eProsima/Fast-DDS/pull/4860
<!--
    Describe changes in detail.
    This includes depicting the context, use case or current behavior and describe the proposed changes.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->

## Contributor Checklist
- [x] Commit messages follow the company guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [x] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- [x] New features have been added to the `versions.md` and `README.md` files (if applicable).

## Reviewer Checklist
- [x] The title and description correctly express the PR's purpose.
- [x] The Contributor checklist is correctly filled.
