### PR TITLE
[21226] Add `skip_base` input option to `get_related_branch_from_repo` action

### DIFF
--- a/multiplatform/get_related_branch_from_repo/action.yml
+++ b/multiplatform/get_related_branch_from_repo/action.yml
@@ -5,8 +5,8 @@ description: >
   In case the event triggering the workflow is a "pull_request", the branch deduction is as follows:
 
     1. The action will look for the PR's source branch in the remote repository.
-    2. If the PR's source branch is not found, the action will look for the PR's base branch in the remote repository.
-    3. If the PR's base branch is not found, the action will look for the fallback branch in the remote repository.
+    2. If the PR's source branch is not found and this step is not skipped, the action will look for the PR's base branch in the remote repository.
+    3. If the PR's base branch is not found or skipped, the action will look for the fallback branch in the remote repository.
     4. If the fallback branch is not found, the action will fail.
 
   In case the event triggering the workflow is not a "pull_request", the action will look for the fallback branch in the remote repository, and fail if it is not found.

--- a/multiplatform/get_related_branch_from_repo/action.yml
+++ b/multiplatform/get_related_branch_from_repo/action.yml
@@ -25,6 +25,13 @@ inputs:
       This is the only branch that is checked for existence in the remote repository in events other that "pull_request".
     required: true
 
+  skip_base:
+    description: >
+      Skip the base branch deduction in case the PR's source branch is not found.
+      This is useful when the base branch is not relevant for the workflow.
+    required: false
+    default: false
+
 outputs:
   deduced_branch:
     description: "Deduced branch"
@@ -41,3 +48,4 @@ runs:
       with:
         remote_repository: ${{ inputs.remote_repository }}
         fallback_branch: ${{ inputs.fallback_branch }}
+        skip_base: ${{ inputs.skip_base }}

--- a/ubuntu/get_related_branch_from_repo/action.yml
+++ b/ubuntu/get_related_branch_from_repo/action.yml
@@ -25,6 +25,13 @@ inputs:
       This is the only branch that is checked for existence in the remote repository in events other that "pull_request".
     required: true
 
+  skip_base:
+    description: >
+      Skip the base branch deduction in case the PR's source branch is not found.
+      This is useful when the base branch is not relevant for the workflow.
+    required: false
+    default: false
+
 outputs:
   deduced_branch:
     description: "Deduced branch"
@@ -75,7 +82,7 @@ runs:
           fi
 
           # Attempt to use PR's base branch
-          if [ ${exit_code} == "1" ] && [ $(branch_exists ${remote_repo} ${{ github.base_ref }}) == "true" ]
+          if [ ${exit_code} == "1" ] && [${{ inputs.skip_base }} == "false"] && [ $(branch_exists ${remote_repo} ${{ github.base_ref }}) == "true" ]
           then
             result_branch=${{ github.base_ref }}
             exit_code=0

--- a/ubuntu/get_related_branch_from_repo/action.yml
+++ b/ubuntu/get_related_branch_from_repo/action.yml
@@ -5,8 +5,8 @@ description: >
   In case the event triggering the workflow is a "pull_request", the branch deduction is as follows:
 
     1. The action will look for the PR's source branch in the remote repository.
-    2. If the PR's source branch is not found, the action will look for the PR's base branch in the remote repository.
-    3. If the PR's base branch is not found, the action will look for the fallback branch in the remote repository.
+    2. If the PR's source branch is not found and this step is not skipped, the action will look for the PR's base branch in the remote repository.
+    3. If the PR's base branch is not found or skipped, the action will look for the fallback branch in the remote repository.
     4. If the fallback branch is not found, the action will fail.
 
   In case the event triggering the workflow is not a "pull_request", the action will look for the fallback branch in the remote repository, and fail if it is not found.

--- a/versions.md
+++ b/versions.md
@@ -38,6 +38,8 @@ The [Forthcoming](#forthcoming) section includes those features added in `main` 
 
 The upcoming release will include the following **features**:
 
+- Add `skip_base` option to the `get_related_branch_from_repo` action so base branch is not considered.
+
 ## v0.24.0
 
 - Fix the windows action colcon build to accept multiple colcon meta files.


### PR DESCRIPTION
<!--
    Provide a general summary of your changes in the Title above
    It must be meaningful and coherent with the changes
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
-->

## Description
The `get_releated_branch_from_repo` action tries to find a branch with the same reference (name) in the given repo.
If fails, tries to get a branch with the same base name, else the given fallback branch.
We have already experience some issues with this actions, because it is used by eProsima products supported branches in nightly CI (for instance, lets say Fast DDS Gen 2.5.x), and instead of using the fallback of other product (Fast DDS 2.14.x), it finds a base branch in the repo that was not desired to be used (Fast DDS 2.5.x in this case).
This PR allows skipping the base branch step, so if the ref branch is not found, it uses directly the given fallback branch.
<!--
    Describe changes in detail.
    This includes depicting the context, use case or current behavior and describe the proposed changes.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->

## Contributor Checklist
- [x] Commit messages follow the company guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [x] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- [x] New features have been added to the `versions.md` and `README.md` files (if applicable).

## Reviewer Checklist
- [x] The title and description correctly express the PR's purpose.
- [x] The Contributor checklist is correctly filled.
