### PR TITLE
[21546] Add `include-hidden-files` input as `true`

### DIFF
--- a/external/upload-artifact/action.yml
+++ b/external/upload-artifact/action.yml
@@ -24,6 +24,12 @@ inputs:
 
       Minimum 1 day.
       Maximum 90 days unless changed from the repository settings page.
+  include-hidden-files:
+    description: >
+      Whether to include hidden files in the provided path in the artifact
+      The file contents of any hidden files in the path should be validated before
+      enabled this to avoid uploading sensitive information.
+    default: 'true'
 
 runs:
   using: composite
@@ -40,9 +46,10 @@ runs:
         echo "::endgroup::"
 
     - name: Upload artifacts
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v4.4
       with:
-        name:               ${{ env.normalized_name }}
-        path:               ${{ inputs.path }}
-        if-no-files-found:  ${{ inputs.if-no-files-found }}
-        retention-days:     ${{ inputs.retention-days }}
+        name:                 ${{ env.normalized_name }}
+        path:                 ${{ inputs.path }}
+        if-no-files-found:    ${{ inputs.if-no-files-found }}
+        retention-days:       ${{ inputs.retention-days }}
+        include-hidden-files: ${{ inputs.include-hidden-files }}

--- a/external/upload-artifact/action.yml
+++ b/external/upload-artifact/action.yml
@@ -46,7 +46,7 @@ runs:
         echo "::endgroup::"
 
     - name: Upload artifacts
-      uses: actions/upload-artifact@v4.4
+      uses: actions/upload-artifact@v4
       with:
         name:                 ${{ env.normalized_name }}
         path:                 ${{ inputs.path }}

--- a/versions.md
+++ b/versions.md
@@ -39,7 +39,6 @@ The [Forthcoming](#forthcoming) section includes those features added in `main` 
 
 The upcoming release will include the following **features**:
 
-- Fix [upload-artifact](/external/upload-artifact/action.yml) action version to `v4.4`.
 - Add `include-hidden-files` input as `true` by default to the [upload-artifact](/external/upload-artifact/action.yml) action.
 
 ## v0.25.0

--- a/versions.md
+++ b/versions.md
@@ -39,6 +39,9 @@ The [Forthcoming](#forthcoming) section includes those features added in `main` 
 
 The upcoming release will include the following **features**:
 
+- Fix [upload-artifact](/external/upload-artifact/action.yml) action version to `v4.4`.
+- Add `include-hidden-files` input as `true` by default to the [upload-artifact](/external/upload-artifact/action.yml) action.
+
 ## v0.25.0
 
 - Add `skip_base` option to the `get_related_branch_from_repo` action so base branch is not considered.


### PR DESCRIPTION
<!--
    Provide a general summary of your changes in the Title above
    It must be meaningful and coherent with the changes
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
-->

## Description
The upload artifact action has been updated with a v4.4 release with a behavior change: [hidden files are excluded by default](https://github.com/actions/upload-artifact?tab=readme-ov-file#breaking-changes).
This PR adds the `include-hidden-files` input as `true` by default

 

That has broken some of our CI pipelines
<!--
    Describe changes in detail.
    This includes depicting the context, use case or current behavior and describe the proposed changes.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->

## Contributor Checklist
- [x] Commit messages follow the company guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [x] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- [x] New features have been added to the `versions.md` and `README.md` files (if applicable).

## Reviewer Checklist
- [x] The title and description correctly express the PR's purpose.
- [x] The Contributor checklist is correctly filled.
