### PR TITLE
Improve branch filter on `get_related_branch_from_repo`

### DIFF
--- a/ubuntu/get_related_branch_from_repo/action.yml
+++ b/ubuntu/get_related_branch_from_repo/action.yml
@@ -57,7 +57,7 @@ runs:
         {
           ret="false";
 
-          if [[ $(git ls-remote ${1} ${2} | wc -l) != 0 ]]
+          if [[ $(git ls-remote ${1} refs/heads/${2} | wc -l) != 0 ]]
           then
             ret="true"
           fi


### PR DESCRIPTION
<!--
    Provide a general summary of your changes in the Title above
    It must be meaningful and coherent with the changes
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
-->

## Description

<!--
    Describe changes in detail.
    This includes depicting the context, use case or current behavior and describe the proposed changes.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->

When listing the branches on the remote repo, `git ls-remote` gets all references that match the input argument at the end of the ref name. This means that a branch named `feature/foo/main` will match when querying for `main`. This is making [this](https://github.com/eProsima/Fast-DDS-python/actions/runs/13515820243/job/37764209385) fail.

This PR changes the `branch_exists` function, prepending `refs/heads/` to the branch name, which makes it to only match when the full string matches.

## Contributor Checklist
- [ ] Commit messages follow the company guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [x] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- [ ] New features have been added to the `versions.md` and `README.md` files (if applicable).

## Reviewer Checklist
- [ ] The title and description correctly express the PR's purpose.
- [ ] The Contributor checklist is correctly filled.
