### PR TITLE
[23012] Make `get_related_branch_from_repo()` action compatible with MacOS

### DIFF
--- a/ubuntu/get_related_branch_from_repo/action.yml
+++ b/ubuntu/get_related_branch_from_repo/action.yml
@@ -57,10 +57,10 @@ runs:
         {
           ret="false";
 
-          if [[ $(git ls-remote ${1} refs/heads/${2} | wc -l) != 0 ]]
+          if [[ $(git ls-remote ${1} refs/heads/${2} | wc -l | sed 's/ //g') != 0 ]]
           then
             ret="true"
-          elif [[ $(git ls-remote ${1} refs/tags/${2} | wc -l) != 0 ]]
+          elif [[ $(git ls-remote ${1} refs/tags/${2} | wc -l | sed 's/ //g') != 0 ]]
           then
             ret="true"
           fi


### PR DESCRIPTION
<!--
    Provide a general summary of your changes in the Title above
    It must be meaningful and coherent with the changes
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
-->

## Description

<!--
    Describe changes in detail.
    This includes depicting the context, use case or current behavior and describe the proposed changes.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->

This PR addresses an issue with the `get_related_branch_from_repo()`.
In `MacOS` the `wc -l` is returning the output with spaces, which makes `branch_exists()` to return `true` on inexistent branches.

Thanks @Carlosespicur for the hints

## Contributor Checklist
- [X] Commit messages follow the company guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [X] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- **N/A** New features have been added to the `versions.md` and `README.md` files (if applicable).

## Reviewer Checklist
- [x] The title and description correctly express the PR's purpose.
- [ ] The Contributor checklist is correctly filled.
