### PR TITLE
[21670] Enable to build TSAN binary as single version

### DIFF
--- a/.github/workflows/build_ddspipe.yml
+++ b/.github/workflows/build_ddspipe.yml
@@ -358,10 +358,20 @@ jobs:
           colcon_meta_file_result: ${{ github.workspace }}/colcon.meta
           repos_file_result: ${{ github.workspace }}/dependencies.repos
 
+      # If single version build is set to false, fetch the repositories with vcs-tool
       - name: Fetch DDS Pipe repositories with vcs-tool
+        if: ${{ inputs.single_version_build == 'false' }}
         uses: eProsima/eProsima-CI/multiplatform/vcs_import@main
         with:
           vcs_repos_file: ${{ github.workspace }}/dependencies.repos
+          destination_workspace: ${{ github.workspace }}/src
+
+      # If single version build is set to true, fetch the repositories manually
+      - name: Fetch DDS Pipe repositories
+        if: ${{ inputs.single_version_build == 'true' }}
+        uses: eProsima/eProsima-CI/multiplatform/fetch_ddspipe_manual@main
+        with:
+          ddspipe_branch: ${{ inputs.ddspipe_branch || env.default_ddspipe_branch }}
           destination_workspace: ${{ github.workspace }}/src
 
       - name: Build workspace

--- a/.github/workflows/build_ddspipe.yml
+++ b/.github/workflows/build_ddspipe.yml
@@ -150,7 +150,7 @@ jobs:
       foonathan_memory_vendor_branch: ${{ inputs.foonathan_memory_vendor_branch }}
       fastcdr_branch: ${{ inputs.fastcdr_branch }}
       fastdds_branch: ${{ inputs.fastdds_branch }}
-      build_with_tsan: ${{ inputs.build_with_tsan }}
+      build_with_tsan: ${{ inputs.build_with_tsan || true }}
 
 
   build_ddspipe_single_version:
@@ -351,6 +351,7 @@ jobs:
         with:
           source_repository_branch: ${{ inputs.configuration_branch || env.default_configuration_branch }}
           colcon_meta_file_path: .github/workflows/configurations/metas/ubuntu-22.04_tsan/colcon.meta
+          # If single version build is set to true, use the single version repos file, otherwise use the versioned repos file
           repos_file_path: ${{ inputs.single_version_build
                                     && env.REPOS_FILE_SINGLE_VERSION
                                     || format('.github/workflows/configurations/ddspipe/deps_{0}.repos', matrix.fastdds_version) }}
@@ -360,7 +361,7 @@ jobs:
 
       # If single version build is set to false, fetch the repositories with vcs-tool
       - name: Fetch DDS Pipe repositories with vcs-tool
-        if: ${{ inputs.single_version_build == 'false' }}
+        if: ${{ contains(inputs.single_version_build, 'false') }}
         uses: eProsima/eProsima-CI/multiplatform/vcs_import@main
         with:
           vcs_repos_file: ${{ github.workspace }}/dependencies.repos
@@ -368,7 +369,7 @@ jobs:
 
       # If single version build is set to true, fetch the repositories manually
       - name: Fetch DDS Pipe repositories
-        if: ${{ inputs.single_version_build == 'true' }}
+        if: ${{ contains(inputs.single_version_build, 'true') }}
         uses: eProsima/eProsima-CI/multiplatform/fetch_ddspipe_manual@main
         with:
           ddspipe_branch: ${{ inputs.ddspipe_branch || env.default_ddspipe_branch }}

--- a/.github/workflows/build_ddspipe.yml
+++ b/.github/workflows/build_ddspipe.yml
@@ -313,14 +313,15 @@ jobs:
     runs-on: ubuntu-22.04
     strategy:
       matrix:
-        fastdds_version:
-          - v2
-          - v3
+        ${{ inputs.single_version_build
+                 && fromJSON('{"fastdds_version":["custom"]}')
+                 || fromJSON('{"fastdds_version":["v2","v3"]}') }}
       fail-fast: false
     env:
       CC: gcc-12
       CXX: g++-12
       TSAN_OPTIONS: second_deadlock_stack=1 history_size=7 memory_limit_mb=5000
+      REPOS_FILE_SINGLE_VERSION: .github/workflows/configurations/ddspipe/dependencies.repos
 
     steps:
 
@@ -350,7 +351,10 @@ jobs:
         with:
           source_repository_branch: ${{ inputs.configuration_branch || env.default_configuration_branch }}
           colcon_meta_file_path: .github/workflows/configurations/metas/ubuntu-22.04_tsan/colcon.meta
-          repos_file_path: .github/workflows/configurations/ddspipe/deps_${{ matrix.fastdds_version }}.repos
+          repos_file_path: ${{ inputs.single_version_build
+                                    && env.REPOS_FILE_SINGLE_VERSION
+                                    || format('.github/workflows/configurations/ddspipe/deps_{0}.repos', matrix.fastdds_version) }}
+
           colcon_meta_file_result: ${{ github.workspace }}/colcon.meta
           repos_file_result: ${{ github.workspace }}/dependencies.repos
 

--- a/.github/workflows/build_dev_utils.yml
+++ b/.github/workflows/build_dev_utils.yml
@@ -395,10 +395,20 @@ jobs:
           colcon_meta_file_result: ${{ github.workspace }}/colcon.meta
           repos_file_result: ${{ github.workspace }}/dependencies.repos
 
+      # If single version build is set to false, fetch the repositories with vcs-tool
       - name: Fetch dev-utils repositories with vcs-tool
+        if: ${{ inputs.single_version_build == false }}
         uses: eProsima/eProsima-CI/multiplatform/vcs_import@main
         with:
           vcs_repos_file: ${{ github.workspace }}/dependencies.repos
+          destination_workspace: ${{ github.workspace }}/src
+
+      # If single version build is set to true, fetch the repositories manually
+      - name: Fetch dev-utils repositories
+        if: ${{ inputs.single_version_build == true }}
+        uses: eProsima/eProsima-CI/multiplatform/fetch_dev_utils_manual@main
+        with:
+          dev_utils_branch: ${{ inputs.dev_utils_branch || env.default_dev_utils_branch }}
           destination_workspace: ${{ github.workspace }}/src
 
       - name: Build workspace

--- a/.github/workflows/build_dev_utils.yml
+++ b/.github/workflows/build_dev_utils.yml
@@ -356,14 +356,15 @@ jobs:
     runs-on: ubuntu-22.04
     strategy:
       matrix:
-        fastdds_version:
-          - v2
-          - v3
+        ${{ inputs.single_version_build
+                 && fromJSON('{"fastdds_version":["custom"]}')
+                 || fromJSON('{"fastdds_version":["v2","v3"]}') }}
       fail-fast: false
     env:
       CC: gcc-12
       CXX: g++-12
       TSAN_OPTIONS: second_deadlock_stack=1 history_size=7 memory_limit_mb=5000
+      REPOS_FILE_SINGLE_VERSION: .github/workflows/configurations/dev_utils/dependencies.repos
 
     steps:
 
@@ -388,7 +389,9 @@ jobs:
         with:
           source_repository_branch: ${{ inputs.configuration_branch || env.default_configuration_branch }}
           colcon_meta_file_path: .github/workflows/configurations/metas/ubuntu-22.04_tsan/colcon.meta
-          repos_file_path: .github/workflows/configurations/dev_utils/deps_${{ matrix.fastdds_version }}.repos
+          repos_file_path: ${{ inputs.single_version_build
+                                    && env.REPOS_FILE_SINGLE_VERSION
+                                    || format('.github/workflows/configurations/dev_utils/deps_{0}.repos', matrix.fastdds_version) }}
           colcon_meta_file_result: ${{ github.workspace }}/colcon.meta
           repos_file_result: ${{ github.workspace }}/dependencies.repos
 

--- a/.github/workflows/build_dev_utils.yml
+++ b/.github/workflows/build_dev_utils.yml
@@ -203,7 +203,7 @@ jobs:
       foonathan_memory_vendor_branch: ${{ inputs.foonathan_memory_vendor_branch }}
       fastcdr_branch: ${{ inputs.fastcdr_branch }}
       fastdds_branch: ${{ inputs.fastdds_branch }}
-      build_with_tsan: ${{ inputs.build_with_tsan }}
+      build_with_tsan: ${{ inputs.build_with_tsan || true }}
 
 
   build_dev_utils_single_version:

--- a/.github/workflows/build_dev_utils.yml
+++ b/.github/workflows/build_dev_utils.yml
@@ -389,6 +389,7 @@ jobs:
         with:
           source_repository_branch: ${{ inputs.configuration_branch || env.default_configuration_branch }}
           colcon_meta_file_path: .github/workflows/configurations/metas/ubuntu-22.04_tsan/colcon.meta
+          # If single version build is set to true, use the single version repos file, otherwise use the versioned repos file
           repos_file_path: ${{ inputs.single_version_build
                                     && env.REPOS_FILE_SINGLE_VERSION
                                     || format('.github/workflows/configurations/dev_utils/deps_{0}.repos', matrix.fastdds_version) }}
@@ -397,7 +398,7 @@ jobs:
 
       # If single version build is set to false, fetch the repositories with vcs-tool
       - name: Fetch dev-utils repositories with vcs-tool
-        if: ${{ inputs.single_version_build == false }}
+        if: ${{ contains(inputs.single_version_build, 'false') }}
         uses: eProsima/eProsima-CI/multiplatform/vcs_import@main
         with:
           vcs_repos_file: ${{ github.workspace }}/dependencies.repos
@@ -405,7 +406,7 @@ jobs:
 
       # If single version build is set to true, fetch the repositories manually
       - name: Fetch dev-utils repositories
-        if: ${{ inputs.single_version_build == true }}
+        if: ${{ contains(inputs.single_version_build, 'true') }}
         uses: eProsima/eProsima-CI/multiplatform/fetch_dev_utils_manual@main
         with:
           dev_utils_branch: ${{ inputs.dev_utils_branch || env.default_dev_utils_branch }}

--- a/.github/workflows/build_fastdds.yml
+++ b/.github/workflows/build_fastdds.yml
@@ -342,10 +342,22 @@ jobs:
           colcon_meta_file_result: ${{ github.workspace }}/colcon.meta
           repos_file_result: ${{ github.workspace }}/dependencies.repos
 
+      # If single version build is set to false, fetch the repositories with vcs-tool
       - name: Fetch Fast DDS repositories with vcs-tool
+        if: ${{ inputs.single_version_build == 'false' }}
         uses: eProsima/eProsima-CI/multiplatform/vcs_import@main
         with:
           vcs_repos_file: ${{ github.workspace }}/dependencies.repos
+          destination_workspace: ${{ github.workspace }}/artifact/src
+
+      # If single version build is set to true, fetch the repositories manually
+      - name: Fetch Fast DDS repositories
+        if: ${{ inputs.single_version_build == 'true' }}
+        uses: eProsima/eProsima-CI/multiplatform/fetch_fastdds_manual@main
+        with:
+          foonathan_memory_vendor_branch: ${{ inputs.foonathan_memory_vendor_branch || env.default_foonathan_memory_vendor_branch }}
+          fastcdr_branch: ${{ inputs.fastcdr_branch || env.default_fastcdr_branch }}
+          fastdds_branch: ${{ inputs.fastdds_branch || env.default_fastdds_branch }}
           destination_workspace: ${{ github.workspace }}/artifact/src
 
       - name: Build workspace

--- a/.github/workflows/build_fastdds.yml
+++ b/.github/workflows/build_fastdds.yml
@@ -309,14 +309,15 @@ jobs:
     if: ${{ github.event_name == 'schedule' || contains(inputs.build_with_tsan, 'true') }}
     strategy:
       matrix:
-        fastdds_version:
-          - v2
-          - v3
+        ${{ inputs.single_version_build
+                 && fromJSON('{"fastdds_version":["custom"]}')
+                 || fromJSON('{"fastdds_version":["v2","v3"]}') }}
       fail-fast: false
     env:
       CC: gcc-12
       CXX: g++-12
       TSAN_OPTIONS: second_deadlock_stack=1 history_size=7 memory_limit_mb=5000
+      REPOS_FILE_SINGLE_VERSION: .github/workflows/configurations/fastdds/dependencies.repos
 
     steps:
 
@@ -335,7 +336,9 @@ jobs:
         with:
           source_repository_branch: ${{ inputs.configuration_branch || env.default_configuration_branch }}
           colcon_meta_file_path: .github/workflows/configurations/metas/ubuntu-22.04_tsan/colcon.meta
-          repos_file_path: .github/workflows/configurations/fastdds/deps_${{ matrix.fastdds_version }}.repos
+          repos_file_path: ${{ inputs.single_version_build
+                                    && env.REPOS_FILE_SINGLE_VERSION
+                                    || format('.github/workflows/configurations/fastdds/deps_{0}.repos', matrix.fastdds_version) }}
           colcon_meta_file_result: ${{ github.workspace }}/colcon.meta
           repos_file_result: ${{ github.workspace }}/dependencies.repos
 

--- a/.github/workflows/build_fastdds.yml
+++ b/.github/workflows/build_fastdds.yml
@@ -336,6 +336,7 @@ jobs:
         with:
           source_repository_branch: ${{ inputs.configuration_branch || env.default_configuration_branch }}
           colcon_meta_file_path: .github/workflows/configurations/metas/ubuntu-22.04_tsan/colcon.meta
+          # If single version build is set to true, use the single version repos file, otherwise use the versioned repos file
           repos_file_path: ${{ inputs.single_version_build
                                     && env.REPOS_FILE_SINGLE_VERSION
                                     || format('.github/workflows/configurations/fastdds/deps_{0}.repos', matrix.fastdds_version) }}
@@ -344,7 +345,7 @@ jobs:
 
       # If single version build is set to false, fetch the repositories with vcs-tool
       - name: Fetch Fast DDS repositories with vcs-tool
-        if: ${{ inputs.single_version_build == 'false' }}
+        if: ${{ contains(inputs.single_version_build, 'false') }}
         uses: eProsima/eProsima-CI/multiplatform/vcs_import@main
         with:
           vcs_repos_file: ${{ github.workspace }}/dependencies.repos
@@ -352,7 +353,7 @@ jobs:
 
       # If single version build is set to true, fetch the repositories manually
       - name: Fetch Fast DDS repositories
-        if: ${{ inputs.single_version_build == 'true' }}
+        if: ${{ contains(inputs.single_version_build, 'true') }}
         uses: eProsima/eProsima-CI/multiplatform/fetch_fastdds_manual@main
         with:
           foonathan_memory_vendor_branch: ${{ inputs.foonathan_memory_vendor_branch || env.default_foonathan_memory_vendor_branch }}

--- a/.github/workflows/configurations/ddspipe/dependencies.repos
+++ b/.github/workflows/configurations/ddspipe/dependencies.repos
@@ -3,4 +3,3 @@ repositories:
     dds_pipe:
         type: git
         url: https://github.com/eProsima/DDS-Pipe.git
-        version: main

--- a/.github/workflows/configurations/dev_utils/dependencies.repos
+++ b/.github/workflows/configurations/dev_utils/dependencies.repos
@@ -3,4 +3,3 @@ repositories:
     dev_utils:
         type: git
         url: https://github.com/eProsima/dev-utils.git
-        version: main

--- a/.github/workflows/configurations/fastdds/dependencies.repos
+++ b/.github/workflows/configurations/fastdds/dependencies.repos
@@ -3,14 +3,11 @@ repositories:
     foonathan_memory_vendor:
         type: git
         url: https://github.com/eProsima/foonathan_memory_vendor.git
-        version: master
 
     fastcdr:
         type: git
         url: https://github.com/eProsima/Fast-CDR.git
-        version: 2.2.x
 
     fastdds:
         type: git
         url: https://github.com/eProsima/Fast-DDS.git
-        version: 2.x

--- a/.github/workflows/configurations/metas/ubuntu-22.04_tsan/colcon.meta
+++ b/.github/workflows/configurations/metas/ubuntu-22.04_tsan/colcon.meta
@@ -5,9 +5,23 @@
             - "-DCMAKE_CXX_FLAGS='-fsanitize=thread -O2 -g -fno-omit-frame-pointer'"
     "fastdds":
         "cmake-args":
-            - "-DCOMPILE_EXAMPLES=ON"
+            - "-DCOMPILE_EXAMPLES=OFF"
             - "-DEPROSIMA_BUILD_TESTS=OFF"
             - "-DRTPS_API_TESTS=OFF"
+            - "-DFASTDDS_PIM_API_TESTS=OFF"
+            - "-DPERFORMANCE_TESTS=OFF"
+            - "-DNO_TLS=OFF"
+            - "-DSECURITY=ON"
+            - "-DFASTDDS_STATISTICS=ON"
+            - "-DCMAKE_C_FLAGS='-fsanitize=thread -O2 -g -fno-omit-frame-pointer'"
+            - "-DCMAKE_CXX_FLAGS='-fsanitize=thread -O2 -g -fno-omit-frame-pointer'"
+
+    "fastrtps":
+        "cmake-args":
+            - "-DCOMPILE_EXAMPLES=OFF"
+            - "-DEPROSIMA_BUILD_TESTS=OFF"
+            - "-DRTPS_API_TESTS=OFF"
+            - "-DFASTRTPS_API_TESTS=OFF"
             - "-DFASTDDS_PIM_API_TESTS=OFF"
             - "-DPERFORMANCE_TESTS=OFF"
             - "-DNO_TLS=OFF"


### PR DESCRIPTION
<!--
    Provide a general summary of your changes in the Title above
    It must be meaningful and coherent with the changes
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
-->

## Description

This PR extends https://github.com/eProsima/eProsima-CI/pull/150 to make it compatible with the `single_version` argument. In this way, if the flag `single_version` is set to true, TSAN binaries will be created with the `custom` name.

## Contributor Checklist
- [x] Commit messages follow the company guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [x] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- _N/A_ New features have been added to the `versions.md` and `README.md` files (if applicable).

## Reviewer Checklist
- [ ] The title and description correctly express the PR's purpose.
- [ ] The Contributor checklist is correctly filled.
