### PR TITLE
Pull repos in VCS action

### DIFF
--- a/macos/install_colcon/action.yml
+++ b/macos/install_colcon/action.yml
@@ -1,6 +1,13 @@
 name: 'install_colcon'
 description: 'Install colcon'
 
+inputs:
+
+  mixins:
+    description: 'Whether to register the default colcon mixin repository'
+    required: false
+    default: 'false'
+
 runs:
   using: composite
   steps:
@@ -12,6 +19,7 @@ runs:
         upgrade: true
 
     - name: Download default colcon mixin
+      if: ${{ inputs.mixins == 'true' }}
       shell: bash
       run: |
         colcon mixin add default https://raw.githubusercontent.com/colcon/colcon-mixin-repository/master/index.yaml

--- a/multiplatform/install_colcon/action.yml
+++ b/multiplatform/install_colcon/action.yml
@@ -1,6 +1,13 @@
 name: install_colcon
 description: Install Colcon
 
+inputs:
+
+  mixins:
+    description: 'Whether to register the default colcon mixin repository'
+    required: false
+    default: 'false'
+
 runs:
   using: composite
   steps:
@@ -8,11 +15,17 @@ runs:
     - name: Run in ubuntu
       uses: eProsima/eProsima-CI/ubuntu/install_colcon@main
       if: runner.os == 'Linux'
+      with:
+        mixins: ${{ inputs.mixins }}
 
     - name: Run in macOS
       uses: eProsima/eProsima-CI/macos/install_colcon@main
       if: runner.os == 'macOS'
+      with:
+        mixins: ${{ inputs.mixins }}
 
     - name: Run in windows
       uses: eProsima/eProsima-CI/windows/install_colcon@main
       if: runner.os == 'Windows'
+      with:
+        mixins: ${{ inputs.mixins }}

--- a/ubuntu/install_colcon/action.yml
+++ b/ubuntu/install_colcon/action.yml
@@ -8,6 +8,11 @@ inputs:
     required: false
     default: '.venv'
 
+  mixins:
+    description: 'Whether to register the default colcon mixin repository'
+    required: false
+    default: 'false'
+
 runs:
   using: composite
   steps:
@@ -20,6 +25,7 @@ runs:
         upgrade: true
 
     - name: Download default colcon mixin
+      if: ${{ inputs.mixins == 'true' }}
       shell: bash
       run: colcon mixin add default https://raw.githubusercontent.com/colcon/colcon-mixin-repository/master/index.yaml; colcon mixin update default
 

--- a/ubuntu/vcs_import/action.yml
+++ b/ubuntu/vcs_import/action.yml
@@ -17,6 +17,11 @@ inputs:
     required: false
     default: 'false'
 
+  pull:
+    description: 'Fast-forward each imported repo to its upstream after import. Repos without an upstream (tag/detached) are skipped, never fails the step.'
+    required: false
+    default: 'true'
+
 runs:
   using: composite
   steps:
@@ -40,5 +45,34 @@ runs:
         vcs import ${SKIP_EXISTING} ${{ inputs.destination_workspace }} < ${{ inputs.vcs_repos_file }}
 
         echo "::endgroup::"
+
+        if [[ "${{ inputs.pull }}" == "true" ]]
+        then
+          echo "::group::Set upstream tracking branches"
+          git config --global --add safe.directory '*'
+          for d in ${{ inputs.destination_workspace }}/*/
+          do
+            [ -e "${d}.git" ] || continue
+            # Detached HEAD (tag/commit pin) has no branch -> skip, so pulls never fail on it.
+            br=$(git -C "${d}" symbolic-ref --short -q HEAD) || continue
+            if git -C "${d}" show-ref --verify --quiet "refs/remotes/origin/${br}"
+            then
+              git -C "${d}" branch --set-upstream-to="origin/${br}" "${br}" >/dev/null 2>&1 || true
+              echo "${d} -> tracking origin/${br}"
+            fi
+          done
+          echo "::endgroup::"
+
+          echo "::group::Fast-forward repositories to upstream"
+          for d in ${{ inputs.destination_workspace }}/*/
+          do
+            [ -e "${d}.git" ] || continue
+            # No upstream (tag/detached, or unset tracking) -> nothing to pull, skip.
+            git -C "${d}" rev-parse --abbrev-ref '@{u}' >/dev/null 2>&1 || continue
+            git -C "${d}" pull --ff-only --quiet && echo "${d} -> up to date" \
+              || echo "WARN: could not fast-forward ${d}"
+          done
+          echo "::endgroup::"
+        fi
 
       shell: bash

--- a/ubuntu/vcs_import/action.yml
+++ b/ubuntu/vcs_import/action.yml
@@ -48,11 +48,32 @@ runs:
 
         if [[ "${{ inputs.pull }}" == "true" ]]
         then
-          echo "::group::Set upstream tracking branches"
+          export GIT_TERMINAL_PROMPT=0
           git config --global --add safe.directory '*'
-          for d in ${{ inputs.destination_workspace }}/*/
+
+          echo "::group::Get list of imported repositories from ${{ inputs.vcs_repos_file }}"
+          DST="${{ inputs.destination_workspace }}"
+          # Only operate on the repos declared in this .repos file. The workspace may be
+          # persisted/shared and contain unrelated repos owned by other steps/workflows
+          # (e.g. private ones whose credentials are gone), which must not be touched.
+          mapfile -t REPOS < <(awk '
+            /^repositories:[[:space:]]*$/ { inrepo=1; next }
+            inrepo && /^[^[:space:]]/     { inrepo=0 }
+            inrepo {
+              match($0, /^[[:space:]]*/); indent = RLENGTH
+              line = $0; gsub(/^[[:space:]]+|[[:space:]]+$/, "", line)
+              if (line == "" || line ~ /^#/) next
+              if (base == 0) base = indent
+              if (indent == base && line ~ /:$/) { sub(/:$/, "", line); print line }
+            }
+          ' "${{ inputs.vcs_repos_file }}")
+          echo "::endgroup::"
+
+          echo "::group::Set upstream tracking branches"
+          for name in "${REPOS[@]}"
           do
-            [ -e "${d}.git" ] || continue
+            d="${DST%/}/${name}"
+            [ -e "${d}/.git" ] || continue
             # Detached HEAD (tag/commit pin) has no branch -> skip, so pulls never fail on it.
             br=$(git -C "${d}" symbolic-ref --short -q HEAD) || continue
             if git -C "${d}" show-ref --verify --quiet "refs/remotes/origin/${br}"
@@ -64,9 +85,10 @@ runs:
           echo "::endgroup::"
 
           echo "::group::Fast-forward repositories to upstream"
-          for d in ${{ inputs.destination_workspace }}/*/
+          for name in "${REPOS[@]}"
           do
-            [ -e "${d}.git" ] || continue
+            d="${DST%/}/${name}"
+            [ -e "${d}/.git" ] || continue
             # No upstream (tag/detached, or unset tracking) -> nothing to pull, skip.
             if ! git -C "${d}" rev-parse --abbrev-ref '@{u}' >/dev/null 2>&1
             then

--- a/ubuntu/vcs_import/action.yml
+++ b/ubuntu/vcs_import/action.yml
@@ -56,7 +56,11 @@ runs:
           # Only operate on the repos declared in this .repos file. The workspace may be
           # persisted/shared and contain unrelated repos owned by other steps/workflows
           # (e.g. private ones whose credentials are gone), which must not be touched.
-          mapfile -t REPOS < <(awk '
+          REPOS=()
+          while IFS= read -r name
+          do
+            REPOS+=("${name}")
+          done < <(awk '
             /^repositories:[[:space:]]*$/ { inrepo=1; next }
             inrepo && /^[^[:space:]]/     { inrepo=0 }
             inrepo {

--- a/ubuntu/vcs_import/action.yml
+++ b/ubuntu/vcs_import/action.yml
@@ -68,7 +68,11 @@ runs:
           do
             [ -e "${d}.git" ] || continue
             # No upstream (tag/detached, or unset tracking) -> nothing to pull, skip.
-            git -C "${d}" rev-parse --abbrev-ref '@{u}' >/dev/null 2>&1 || continue
+            if ! git -C "${d}" rev-parse --abbrev-ref '@{u}' >/dev/null 2>&1
+            then
+              echo "${d} -> no upstream (tag/detached) -> skip"
+              continue
+            fi
             git -C "${d}" pull --ff-only --quiet && echo "${d} -> up to date" \
               || echo "WARN: could not fast-forward ${d}"
           done

--- a/windows/install_colcon/action.yml
+++ b/windows/install_colcon/action.yml
@@ -1,4 +1,12 @@
 name: 'install_colcon'
+description: 'Install colcon'
+
+inputs:
+
+  mixins:
+    description: 'Whether to register the default colcon mixin repository'
+    required: false
+    default: 'false'
 
 runs:
   using: composite
@@ -11,5 +19,6 @@ runs:
         upgrade: true
 
     - name: Download default colcon mixin
+      if: ${{ inputs.mixins == 'true' }}
       shell: pwsh
       run: colcon mixin add default https://raw.githubusercontent.com/colcon/colcon-mixin-repository/master/index.yaml; colcon mixin update default


### PR DESCRIPTION
<!--
    Provide a general summary of your changes in the Title above
    It must be meaningful and coherent with the changes
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
-->

## Description

This PR adds a new flow in the VCS action to pull each repo after calling importing. It first assigns a ref-head in case it is missing (idempotent) and then performs the pull action. An error is not returned if the pull action fails. 
It also makes `colcon mixins` optionals (not downloaded by default) as they are not used in our repos at the moment but some jobs fail when reaching Github rate limits due to the ~19 petitions of this step.

## Contributor Checklist
- [x] Commit messages follow the company guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [x] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- _N/A_: New features have been added to the `versions.md` and `README.md` files (if applicable).

## Reviewer Checklist
- [ ] The title and description correctly express the PR's purpose.
- [ ] The Contributor checklist is correctly filled.
